### PR TITLE
Fix Makefile dependencies for protocol header generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,14 +40,14 @@ src/protocol/kb-protocol.o: src/protocol/kb-protocol.c src/protocol/kb-protocol.
 src/log.o: src/log.c
 	$(CC) $(COMPILE_FLAGS) $(INCLUDE_FLAGS) $(LIBRARY_FLAGS) -c -o src/log.o src/log.c 
 
-src/r2k.o: src/r2k.c
-	$(CC) $(COMPILE_FLAGS) $(INCLUDE_FLAGS) $(LIBRARY_FLAGS) -c -o src/r2k.o src/r2k.c 
+src/r2k.o: src/r2k.c src/protocol/kb-protocol.h
+	$(CC) $(COMPILE_FLAGS) $(INCLUDE_FLAGS) $(LIBRARY_FLAGS) -c -o src/r2k.o src/r2k.c
 
 src/type-x.o: src/type-x.c
 	$(CC) $(COMPILE_FLAGS) $(INCLUDE_FLAGS) $(LIBRARY_FLAGS) -c -o src/type-x.o src/type-x.c 
 
-src/type-wl.o: src/type-wl.c 
-	$(CC) $(COMPILE_FLAGS) $(INCLUDE_FLAGS) $(LIBRARY_FLAGS) -c -o src/type-wl.o src/type-wl.c 
+src/type-wl.o: src/type-wl.c src/protocol/kb-protocol.h
+	$(CC) $(COMPILE_FLAGS) $(INCLUDE_FLAGS) $(LIBRARY_FLAGS) -c -o src/type-wl.o src/type-wl.c
 
 client: src/log.o src/r2k.o bin $(REQ_WL) $(REQ_XORG) 
 	$(CC) $(COMPILE_FLAGS) $(INCLUDE_FLAGS) $(LIBRARY_FLAGS) -o bin/r2k src/r2k.o $(REQ_WL) $(REQ_XORG) src/log.o 


### PR DESCRIPTION
## Problem
The build was failing with the error:
```
src/type-wl.h:10:10: fatal error: protocol/kb-protocol.h: No such file or directory
```

This occurred because the Makefile didn't properly handle the dependency chain for the generated protocol header files.

## Solution
- Added `src/protocol/kb-protocol.h` dependency to `src/r2k.o` target
- Added `src/protocol/kb-protocol.h` dependency to `src/type-wl.o` target

This ensures that the protocol header is generated via `wayland-scanner` before compiling the source files that depend on it.

## Testing
- ✅ Build now completes successfully with `make`
- ✅ All protocol files are generated correctly
- ✅ No compilation errors

Fixes the missing header file compilation issue.